### PR TITLE
Implement Inn Chef System

### DIFF
--- a/Config/DefaultEngine.ini
+++ b/Config/DefaultEngine.ini
@@ -2,7 +2,7 @@
 
 [/Script/EngineSettings.GameMapsSettings]
 GameDefaultMap=/Game/Maps/Test_Default.Test_Default
-EditorStartupMap=/Game/Maps/Test_Default.Test_Default
+EditorStartupMap=/Game/Maps/Inn/InnMap.InnMap
 GlobalDefaultGameMode=/Game/Blueprints/BP_DonGameModeBase.BP_DonGameModeBase_C
 GameInstanceClass=/Game/Blueprints/GameInstance/BP_DonGameInstance.BP_DonGameInstance_C
 

--- a/Source/Don/Private/GameInstance/SubSystem/KitchenOrderSubsystem.cpp
+++ b/Source/Don/Private/GameInstance/SubSystem/KitchenOrderSubsystem.cpp
@@ -3,6 +3,8 @@
 
 #include "GameInstance/SubSystem/KitchenOrderSubsystem.h"
 
+#include "Inn/Actor/InnChef.h"
+
 bool UKitchenOrderSubsystem::ShouldCreateSubsystem(UObject* Outer) const
 {
 	if (const UWorld* World = Outer->GetWorld())
@@ -22,9 +24,12 @@ FKitchenOrder UKitchenOrderSubsystem::EnqueueKitchenOrder(FKitchenOrder& Order)
 	// 요리사 여유가 있는 경우
 	Order.OrderID = FGuid::NewGuid();
 	Order.RemainingTime = Order.CookingTime;
-	if (true)
+	
+	if (AInnChef* IdleChef = FindIdleChef())
 	{
 		Order.bIsCooking = true;
+		Order.AssignedChef = IdleChef;
+		IdleChef->StartOrder(Order);
 		if (!GetWorld()->GetTimerManager().IsTimerActive(OrderTimerHandle))
 		{
 			GetWorld()->GetTimerManager().SetTimer(
@@ -39,6 +44,27 @@ FKitchenOrder UKitchenOrderSubsystem::EnqueueKitchenOrder(FKitchenOrder& Order)
 	KitchenOrderQueue.Add(Order);
 	OnKitchenOrderAdded.Broadcast(Order);
 	return Order;
+}
+
+FGuid UKitchenOrderSubsystem::FindNextQueuedOrderID() const
+{
+	for (const FKitchenOrder& Order : KitchenOrderQueue)
+	{
+		if (!Order.bIsCooking)
+		{
+			return Order.OrderID;
+		}
+	}
+	return FGuid();
+}
+
+AInnChef* UKitchenOrderSubsystem::FindIdleChef()
+{
+	for (AInnChef* Chef : Chefs)
+	{
+		if (!Chef->IsCooking()) return Chef;
+	}
+	return nullptr;
 }
 
 void UKitchenOrderSubsystem::UpdateKitchenOrders()
@@ -65,8 +91,20 @@ void UKitchenOrderSubsystem::UpdateKitchenOrders()
 	for (int32 i : IndexToRemove)
 	{
 		const FKitchenOrder Order = KitchenOrderQueue[i];
+		Order.AssignedChef->EndOrder();
 		KitchenOrderQueue.RemoveAt(i);
 		OnKitchenOrderRemoved.Broadcast(Order);
+
+		for (FKitchenOrder& NewOrder : KitchenOrderQueue)
+		{
+			if (!NewOrder.bIsCooking)
+			{
+				NewOrder.bIsCooking = true;
+				NewOrder.AssignedChef = Order.AssignedChef;
+				Order.AssignedChef->StartOrder(NewOrder);
+				break;
+			}
+		}
 	}
 
 	if (KitchenOrderQueue.IsEmpty())

--- a/Source/Don/Private/Inn/Actor/InnChef.cpp
+++ b/Source/Don/Private/Inn/Actor/InnChef.cpp
@@ -1,0 +1,49 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+
+#include "Inn/Actor/InnChef.h"
+
+#include "GameInstance/SubSystem/KitchenOrderSubsystem.h"
+
+AInnChef::AInnChef()
+{
+	PrimaryActorTick.bCanEverTick = false;
+}
+
+void AInnChef::BeginPlay()
+{
+	Super::BeginPlay();
+
+	if (UWorld* World = GetWorld())
+	{
+		if (UKitchenOrderSubsystem* Subsystem = World->GetGameInstance()->GetSubsystem<UKitchenOrderSubsystem>())
+		{
+			Subsystem->RegisterChef(this);
+		}
+	}	
+}
+
+void AInnChef::EndPlay(const EEndPlayReason::Type EndPlayReason)
+{
+	if (UWorld* World = GetWorld())
+	{
+		if (UKitchenOrderSubsystem* Subsystem = World->GetGameInstance()->GetSubsystem<UKitchenOrderSubsystem>())
+		{
+			Subsystem->UnregisterChef(this);
+		}
+	}	
+	
+	Super::EndPlay(EndPlayReason);
+}
+
+void AInnChef::StartOrder(const FKitchenOrder& Order)
+{
+	OrderID = Order.OrderID;
+	bIsCooking = true;
+}
+
+void AInnChef::EndOrder()
+{
+	OrderID = FGuid();
+	bIsCooking = false;
+}

--- a/Source/Don/Private/Inn/DonInnLibrary.cpp
+++ b/Source/Don/Private/Inn/DonInnLibrary.cpp
@@ -34,6 +34,14 @@ void UDonInnLibrary::AddKitchenOrder(const UObject* WorldContextObject, FKitchen
 	KitchenOrderSubsystem->EnqueueKitchenOrder(Order);
 }
 
+FGuid UDonInnLibrary::FindNextQueuedKitchenOrder(const UObject* WorldContextObject)
+{
+	UKitchenOrderSubsystem* KitchenOrderSubsystem = UGameplayStatics::GetGameInstance(WorldContextObject)->GetSubsystem<UKitchenOrderSubsystem>();
+	if (KitchenOrderSubsystem == nullptr) return FGuid();
+
+	return KitchenOrderSubsystem->FindNextQueuedOrderID();
+}
+
 void UDonInnLibrary::AddRoomServiceOrder(const UObject* WorldContextObject, FRoomServiceOrder Order)
 {
 	URoomServiceOrderSubsystem* RoomServiceOrderSubsystem = UGameplayStatics::GetGameInstance(WorldContextObject)->GetSubsystem<URoomServiceOrderSubsystem>();

--- a/Source/Don/Public/Data/CuisineAsset.h
+++ b/Source/Don/Public/Data/CuisineAsset.h
@@ -6,6 +6,8 @@
 #include "Engine/DataAsset.h"
 #include "CuisineAsset.generated.h"
 
+class AInnChef;
+
 USTRUCT(BlueprintType)
 struct FKitchenOrder
 {
@@ -41,6 +43,9 @@ struct FKitchenOrder
 
 	UPROPERTY(BlueprintReadOnly, EditAnywhere)
 	int32 RemainingTime;
+
+	UPROPERTY(BlueprintReadOnly)
+	TObjectPtr<AInnChef> AssignedChef;
 };
 
 /**

--- a/Source/Don/Public/GameInstance/SubSystem/KitchenOrderSubsystem.h
+++ b/Source/Don/Public/GameInstance/SubSystem/KitchenOrderSubsystem.h
@@ -7,6 +7,7 @@
 #include "Subsystems/GameInstanceSubsystem.h"
 #include "KitchenOrderSubsystem.generated.h"
 
+class AInnChef;
 DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnKitchenOrderChanged, FKitchenOrder, KitchenOrder);
 DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnKitchenOrderUpdated, const TArray<FKitchenOrder>&, KitchenOrders);
 
@@ -38,9 +39,14 @@ public:
 	TArray<FKitchenOrder>& GetKitchenOrderQueue() { return KitchenOrderQueue; };
 
 	FKitchenOrder EnqueueKitchenOrder(FKitchenOrder& Order);
-	
+	FGuid FindNextQueuedOrderID() const;
+	void RegisterChef(AInnChef* Chef) { if (!Chefs.Contains(Chef)) Chefs.Add(Chef); };
+	void UnregisterChef(AInnChef* Chef) { if (Chefs.Contains(Chef)) Chefs.Remove(Chef); };
+	AInnChef* FindIdleChef();
 private:
 	TArray<FKitchenOrder> KitchenOrderQueue;
+	TArray<AInnChef*> Chefs;
+	TMap<int32, AInnChef*> CookingChefs;
 
 	FTimerHandle OrderTimerHandle;
 	void UpdateKitchenOrders();

--- a/Source/Don/Public/Inn/Actor/InnChef.h
+++ b/Source/Don/Public/Inn/Actor/InnChef.h
@@ -1,0 +1,35 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Data/CuisineAsset.h"
+#include "GameFramework/Actor.h"
+#include "InnChef.generated.h"
+
+struct FKitchenOrder;
+
+UCLASS()
+class DON_API AInnChef : public AActor
+{
+	GENERATED_BODY()
+	
+public:	
+	AInnChef();
+
+protected:
+	virtual void BeginPlay() override;
+	virtual void EndPlay(const EEndPlayReason::Type EndPlayReason) override;
+
+public:
+	FORCEINLINE bool IsCooking() const { return bIsCooking; }
+	void StartOrder(const FKitchenOrder& Order);
+	void EndOrder();
+
+	UPROPERTY(EditDefaultsOnly, BlueprintReadWrite)
+	UTexture2D* ChefImage;
+
+private:
+	bool bIsCooking = false;
+	FGuid OrderID;
+};

--- a/Source/Don/Public/Inn/DonInnLibrary.h
+++ b/Source/Don/Public/Inn/DonInnLibrary.h
@@ -16,15 +16,20 @@ class DON_API UDonInnLibrary : public UBlueprintFunctionLibrary
 {
 	GENERATED_BODY()
 public:
-	// Order
+	// Kitchen
 	UFUNCTION(BlueprintPure, Category = "DonInnLibrary | Kitchen")
 	static FKitchenOrder FindCuisineByName(const UObject* WorldContextObject, FName CuisineName);
 
-	UFUNCTION(BlueprintPure, Category = "DonInnLibrary | RoomService")
-	static FRoomServiceOrder FindRoomServiceByName(const UObject* WorldContextObject, FName RoomServiceName);
-	
 	UFUNCTION(BlueprintCallable, Category = "DonInnLibrary | Kitchen")
 	static void AddKitchenOrder(const UObject* WorldContextObject, FKitchenOrder Order);
+
+	UFUNCTION(BlueprintCallable, Category = "DonInnLibrary | Kitchen")
+	static FGuid FindNextQueuedKitchenOrder(const UObject* WorldContextObject);
+
+
+	// RoomService
+	UFUNCTION(BlueprintPure, Category = "DonInnLibrary | RoomService")
+	static FRoomServiceOrder FindRoomServiceByName(const UObject* WorldContextObject, FName RoomServiceName);
 
 	UFUNCTION(BlueprintCallable, Category = "DonInnLibrary | RoomService")
 	static void AddRoomServiceOrder(const UObject* WorldContextObject, FRoomServiceOrder RoomServiceOrder);


### PR DESCRIPTION
Implemented following features:
Chef actors registered to the kitchen subsystem upon spawning, with support for up to three chefs. Orders assigned to idle chefs and tracked while cooking, allowing multiple concurrent orders per chef. Automatic reassignment of new orders once a chef finishes cooking. UI indication for next queued order with glowing highlight effect.